### PR TITLE
Audit fixes

### DIFF
--- a/contracts/application/core/SimplePlugin.sol
+++ b/contracts/application/core/SimplePlugin.sol
@@ -120,7 +120,8 @@ contract SimplePlugin is DeactivationTimelock, IPlugin, Ownable {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
-        return interfaceId == type(IPlugin).interfaceId;
+        return interfaceId == type(IPlugin).interfaceId 
+          || interfaceId == this.supportsInterface.selector;
     }
 
     /************************************************

--- a/contracts/application/core/SimplePlugin.sol
+++ b/contracts/application/core/SimplePlugin.sol
@@ -76,11 +76,30 @@ contract SimplePlugin is DeactivationTimelock, IPlugin, Ownable {
         address account,
         bytes calldata
     ) external view override returns (uint256) {
+        if (deactivated()) {
+            return 0;
+        }
         return _claimable[account].latest();
     }
 
     /// @return total amount claimable by all accounts
     function totalClaimable() external view override returns (uint256) {
+        if (deactivated()) {
+            return 0;
+        }
+        return _totalOwed;
+    }
+
+    /// @return amount owed to account, regardless of deactivation status
+    function owed(
+        address account, 
+        bytes calldata
+    ) external view returns (uint256) {
+        return _claimable[account].latest();
+    }
+
+    /// @return total amount owed, regardless of deactivation status
+    function totalOwed() external view returns (uint256) {
         return _totalOwed;
     }
 


### PR DESCRIPTION
Backwards compatible, superficial fixes for Cantina audit

- Finding 8: Full ERC165 compliance
- Finding 5: clarify `claimable()` and `totalClaimable()` return values by incorporating `deactivated` status and delineate distinction between "claimable" and "owed" nomenclature by exposing two new external functions `owed()` and `totalOwed()` which replicate the previous (deactivation agnostic) behavior of `claimable()` and `totalClaimable()`, respectively.