### PR TITLE
Create validation check for pools

### DIFF
--- a/contracts/telx/core/PositionRegistry.sol
+++ b/contracts/telx/core/PositionRegistry.sol
@@ -67,6 +67,10 @@ contract PositionRegistry is IPositionRegistry, AccessControl, ReentrancyGuard {
         lastRewardBlock = block.number;
     }
 
+    function validPool(PoolId id) external view override returns (bool) {
+        return telcoinPosition[id] != 0;
+    }
+
     /**
      * @notice Computes a unique identifier for a position
      */
@@ -212,14 +216,14 @@ contract PositionRegistry is IPositionRegistry, AccessControl, ReentrancyGuard {
         int24 tickUpper,
         int128 liquidityDelta
     ) external onlyRole(UNI_HOOK_ROLE) {
+        // Does not fail on invalid poolId, just skips update
+        if (telcoinPosition[poolId] == 0) {
+            return;
+        }
+
         require(
             liquidityDelta != type(int128).min,
             "PositionRegistry: Invalid liquidity delta"
-        );
-
-        require(
-            telcoinPosition[poolId] != 0,
-            "PositionRegistry: Invalid PoolId"
         );
 
         bytes32 positionId = getPositionId(

--- a/contracts/telx/core/TELxIncentiveHook.sol
+++ b/contracts/telx/core/TELxIncentiveHook.sol
@@ -136,17 +136,19 @@ contract TELxIncentiveHook is BaseHook {
         BalanceDelta delta,
         bytes calldata
     ) internal override returns (bytes4, int128) {
-        // Extract current tick directly from pool storage using StateLibrary
-        (, int24 tick, , ) = StateLibrary.getSlot0(poolManager, key.toId());
+        if (registry.validPool(key.toId())) {
+            // Extract current tick directly from pool storage using StateLibrary
+            (, int24 tick, , ) = StateLibrary.getSlot0(poolManager, key.toId());
 
-        // Emit swap event with tick so off-chain logic can check LP range activity
-        emit SwapOccurredWithTick(
-            key.toId(),
-            sender,
-            delta.amount0(),
-            delta.amount1(),
-            tick
-        );
+            // Emit swap event with tick so off-chain logic can check LP range activity
+            emit SwapOccurredWithTick(
+                key.toId(),
+                sender,
+                delta.amount0(),
+                delta.amount1(),
+                tick
+            );
+        }
 
         return (BaseHook.afterSwap.selector, 0);
     }

--- a/contracts/telx/interfaces/IPositionRegistry.sol
+++ b/contracts/telx/interfaces/IPositionRegistry.sol
@@ -22,4 +22,6 @@ interface IPositionRegistry {
         int24 tickUpper,
         int128 liquidityDelta
     ) external;
+
+    function validPool(PoolId id) external view returns (bool);
 }

--- a/contracts/telx/test/MockPositionRegistry.sol
+++ b/contracts/telx/test/MockPositionRegistry.sol
@@ -18,4 +18,8 @@ contract MockPositionRegistry is IPositionRegistry {
         view
         returns (Position[] memory)
     {}
+
+    function validPool(PoolId) external view override returns (bool) {
+        return true;
+    }
 }

--- a/contracts/telx/test/MockTELxIncentiveHook.sol
+++ b/contracts/telx/test/MockTELxIncentiveHook.sol
@@ -11,7 +11,6 @@ import {BeforeSwapDelta, BeforeSwapDeltaLibrary} from "@uniswap/v4-core/src/type
 import {IPositionRegistry} from "../interfaces/IPositionRegistry.sol";
 import {StateLibrary} from "@uniswap/v4-core/src/libraries/StateLibrary.sol";
 
-// TESTING ONLY
 contract MockTELxIncentiveHook is BaseHook {
     using PoolIdLibrary for PoolKey;
 
@@ -100,15 +99,17 @@ contract MockTELxIncentiveHook is BaseHook {
         BalanceDelta delta,
         bytes calldata
     ) internal override returns (bytes4, int128) {
-        (, int24 tick, , ) = StateLibrary.getSlot0(poolManager, key.toId());
+        if (registry.validPool(key.toId())) {
+            (, int24 tick, , ) = StateLibrary.getSlot0(poolManager, key.toId());
 
-        emit SwapOccurredWithTick(
-            key.toId(),
-            sender,
-            delta.amount0(),
-            delta.amount1(),
-            tick
-        );
+            emit SwapOccurredWithTick(
+                key.toId(),
+                sender,
+                delta.amount0(),
+                delta.amount1(),
+                tick
+            );
+        }
 
         return (BaseHook.afterSwap.selector, 0);
     }


### PR DESCRIPTION
Added function to position registry:

```solidity
function validPool(PoolId id) external view override returns (bool) {
        return telcoinPosition[id] != 0;
}
```

Only active pools with listed value will be added. Also, hook does not emit events on calls that do not meet this check.