### PR TITLE
enforce NFT-backed position IDs via `salt` in hooks; remove on-chain getPositionId logic

### DIFF
--- a/contracts/snapshot/adaptors/UniswapAdaptor.sol
+++ b/contracts/snapshot/adaptors/UniswapAdaptor.sol
@@ -27,7 +27,7 @@ contract UniswapAdaptor is ISource, IERC165 {
     function balanceOf(
         address voter
     ) external view override returns (uint256 totalVotingWeight) {
-        bytes32[] memory positionIds = registry.getPositionsByStaker(voter);
+        uint256[] memory positionIds = registry.getTokenIdsByProvider(voter);
 
         for (uint256 i = 0; i < positionIds.length; i++) {
             totalVotingWeight += registry.computeVotingWeight(positionIds[i]);

--- a/contracts/telx/core/TELxIncentiveHook.sol
+++ b/contracts/telx/core/TELxIncentiveHook.sol
@@ -87,7 +87,10 @@ contract TELxIncentiveHook is BaseHook {
         IPoolManager.ModifyLiquidityParams calldata params,
         bytes calldata
     ) internal override returns (bytes4) {
+        uint256 tokenId = uint256(uint160(bytes20(params.salt)));
+
         registry.addOrUpdatePosition(
+            tokenId,
             _resolveUser(sender),
             key.toId(),
             params.tickLower,
@@ -111,7 +114,10 @@ contract TELxIncentiveHook is BaseHook {
         IPoolManager.ModifyLiquidityParams calldata params,
         bytes calldata
     ) internal override returns (bytes4) {
+        uint256 tokenId = uint256(uint160(bytes20(params.salt)));
+
         registry.addOrUpdatePosition(
+            tokenId,
             _resolveUser(sender),
             key.toId(),
             params.tickLower,

--- a/contracts/telx/interfaces/IPositionRegistry.sol
+++ b/contracts/telx/interfaces/IPositionRegistry.sol
@@ -13,11 +13,46 @@ interface IPositionRegistry {
         uint128 liquidity;
     }
 
-    function getPositionsByStaker(
-        address staker
-    ) external view returns (bytes32[] memory);
+    /// @notice Emitted when a position is added or its liquidity is increased
+    event PositionUpdated(
+        uint256 indexed tokenId,
+        address indexed provider,
+        PoolId indexed poolId,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 liquidity
+    );
+
+    /// @notice Emitted when a position's liquidity reaches zero and is removed
+    event PositionRemoved(
+        uint256 indexed tokenId,
+        address indexed provider,
+        PoolId indexed poolId,
+        int24 tickLower,
+        int24 tickUpper
+    );
+
+    /// @notice Emitted when reward tokens are added to a user
+    event RewardsAdded(address indexed provider, uint256 amount);
+
+    /// @notice Emitted when a user successfully claims their reward
+    event RewardsClaimed(address indexed provider, uint256 amount);
+
+    /// @notice Emitted when a router's trust status is updated.
+    event RouterRegistryUpdated(address indexed router, bool listed);
+
+    /// @notice Emitted when the TEL token position is updated for a pool.
+    event TelPositionUpdated(PoolId indexed poolId, uint8 location);
+
+    /// @notice Emitted when a token is subscribed for the first time
+    event Subscribed(uint256 indexed tokenId, address indexed owner);
+
+    function getTokenIdsByProvider(
+        address provider
+    ) external view returns (uint256[] memory);
 
     function addOrUpdatePosition(
+        uint256 tokenId,
         address provider,
         PoolId poolId,
         int24 tickLower,
@@ -28,7 +63,7 @@ interface IPositionRegistry {
     function handleSubscribe(uint256 tokenId) external;
 
     function computeVotingWeight(
-        bytes32 positionId
+        uint256 tokenId
     ) external view returns (uint256);
 
     function activeRouters(address router) external view returns (bool);

--- a/contracts/telx/test/MockTELxIncentiveHook.sol
+++ b/contracts/telx/test/MockTELxIncentiveHook.sol
@@ -65,7 +65,10 @@ contract MockTELxIncentiveHook is BaseHook {
         IPoolManager.ModifyLiquidityParams calldata params,
         bytes calldata
     ) internal override returns (bytes4) {
+        uint256 tokenId = uint256(uint160(bytes20(params.salt)));
+
         registry.addOrUpdatePosition(
+            tokenId,
             _resolveUser(sender),
             key.toId(),
             params.tickLower,
@@ -82,7 +85,10 @@ contract MockTELxIncentiveHook is BaseHook {
         IPoolManager.ModifyLiquidityParams calldata params,
         bytes calldata
     ) internal override returns (bytes4) {
+        uint256 tokenId = uint256(uint160(bytes20(params.salt)));
+
         registry.addOrUpdatePosition(
+            tokenId,
             _resolveUser(sender),
             key.toId(),
             params.tickLower,

--- a/test/snapshot/UniswapAdaptor.test.ts
+++ b/test/snapshot/UniswapAdaptor.test.ts
@@ -56,6 +56,7 @@ describe("UniswapAdaptor", function () {
         await registry.updateTelPosition(dummyPoolId, 1);
         // Seed the registry with an active position
         await registry.addOrUpdatePosition(
+            1,
             user.address,
             dummyPoolId,
             tickLower,


### PR DESCRIPTION
The internal getPositionId() function, which previously derived a hash-based ID from the provider address and position parameters, has been completely removed. Instead, hooks now extract the position ID by converting the salt field into a uint256, using the logic uint256(uint160(bytes20(params.salt))). This value is then passed to the addOrUpdatePosition() function in the PositionRegistry.

This approach requires all liquidity positions to be backed by Uniswap V4 NFTs. Any attempt to interact with positions that do not use an NFT-based salt will cause the transaction to revert with a clear error message ("Only NFT-backed positions supported"). This ensures that position tracking in the registry remains synchronized with actual ownership as determined by NFT transfer logic.