### PR TITLE
Pin deps and fix tests

### DIFF
--- a/contracts/sablier/core/CouncilMember.sol
+++ b/contracts/sablier/core/CouncilMember.sol
@@ -183,7 +183,7 @@ contract CouncilMember is
         bytes4 interfaceId
     )
         public
-        pure
+        view
         override(
             AccessControlEnumerableUpgradeable,
             ERC721EnumerableUpgradeable
@@ -191,10 +191,8 @@ contract CouncilMember is
         returns (bool)
     {
         return
-            interfaceId ==
-            type(AccessControlEnumerableUpgradeable).interfaceId ||
-            interfaceId == type(ERC721EnumerableUpgradeable).interfaceId ||
-            interfaceId == type(IERC721).interfaceId;
+            AccessControlEnumerableUpgradeable.supportsInterface(interfaceId) ||
+            ERC721EnumerableUpgradeable.supportsInterface(interfaceId);
     }
 
     /************************************************

--- a/contracts/telx/core/StakingRewards.sol
+++ b/contracts/telx/core/StakingRewards.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {SafeERC20, IERC20, Address} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {SafeERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "hardhat": "^2.20.1"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.0.1",
-    "@openzeppelin/contracts-upgradeable": "^5.0.1",
-    "@uniswap/v4-core": "^1.0.1",
-    "@uniswap/v4-periphery": "^1.0.1",
+    "@openzeppelin/contracts": "5.4",
+    "@openzeppelin/contracts-upgradeable": "5.4",
+    "@uniswap/v4-core": "1.0.1",
+    "@uniswap/v4-periphery": "1.0.1",
     "dotenv": "^17.2.0"
   }
 }

--- a/test/sablier/CouncilMember.test.ts
+++ b/test/sablier/CouncilMember.test.ts
@@ -17,6 +17,16 @@ describe("CouncilMember", () => {
     let governanceRole: string = ethers.keccak256(ethers.toUtf8Bytes("GOVERNANCE_COUNCIL_ROLE"));
     let supportRole: string = ethers.keccak256(ethers.toUtf8Bytes("SUPPORT_ROLE"));
 
+    // calculate interface IDs
+    const calculateInterfaceId = (functionSignatures: string[]): string => {
+        let interfaceId = 0;
+        for (const sig of functionSignatures) {
+            const hash = ethers.keccak256(ethers.toUtf8Bytes(sig));
+            interfaceId ^= parseInt(hash.slice(0, 10));
+        }
+        return '0x' + interfaceId.toString(16).padStart(8, '0');
+    };
+
     beforeEach(async () => {
         [admin, support, member, holder, target] = await ethers.getSigners();
 
@@ -69,11 +79,24 @@ describe("CouncilMember", () => {
             });
 
             it("has AccessControlEnumerableUpgradeable interface", async () => {
-                expect(await councilMember.supportsInterface('0x5bfad1a8')).to.equal(true);
+                // IAccessControlEnumerable interface from OpenZeppelin v5
+                const interfaceId = calculateInterfaceId([
+                    'getRoleMember(bytes32,uint256)',
+                    'getRoleMemberCount(bytes32)'
+                ]);
+                expect(await councilMember.supportsInterface(interfaceId)).to.equal(true);
+                // expect(await councilMember.supportsInterface('0x5bfad1a8')).to.equal(true);
             });
 
             it("has ERC721EnumerableUpgradeable interface", async () => {
-                expect(await councilMember.supportsInterface('0x79f154c4')).to.equal(true);
+                // IERC721Enumerable interface
+                const interfaceId = calculateInterfaceId([
+                    'totalSupply()',
+                    'tokenOfOwnerByIndex(address,uint256)',
+                    'tokenByIndex(uint256)'
+                ]);
+                expect(await councilMember.supportsInterface(interfaceId)).to.equal(true);
+                // expect(await councilMember.supportsInterface('0x79f154c4')).to.equal(true);
             });
         });
 
@@ -496,4 +519,4 @@ describe("CouncilMember", () => {
         });
     });
 });
-//supportsInterface 
+//supportsInterface


### PR DESCRIPTION
- pin deps in `package.json`
- update tests to calculate `interfaceIds` (broken after OpenZeppelin update 5.0.1 -> 5.4)